### PR TITLE
chore: bump up shell version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Overview Hover",
   "description": "Hover over a window in overview mode to make it active",
   "shell-version": [
-    "45", "46", "47"
+    "45", "46", "47", "48"
   ],
   "url": "https://github.com/mattdavis90/overview-hover"
 }


### PR DESCRIPTION
support shell version 48