### PR TITLE
Add support for shell version 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Overview Hover",
   "description": "Hover over a window in overview mode to make it active",
   "shell-version": [
-    "45", "46", "47"
+    "45", "46", "47", "49"
   ],
   "url": "https://github.com/mattdavis90/overview-hover"
 }


### PR DESCRIPTION
I added shell-version 49 in metadata.json and tested it. It works.